### PR TITLE
Fix deprecated types in `typing`

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -4,14 +4,14 @@ This module provides fixtures for doctests.
 Note that this file will NOT be included when installed.
 """
 import base64
-import typing as t
+from collections import abc
 from unittest import mock
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def from_client_config_mock() -> t.Generator[mock.Mock, None, None]:
+def from_client_config_mock() -> abc.Generator[mock.Mock, None, None]:
     """
     For tlab_google.credentials.new_credentials
     """
@@ -22,7 +22,7 @@ def from_client_config_mock() -> t.Generator[mock.Mock, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def from_authorized_user_file_mock() -> t.Generator[mock.Mock, None, None]:
+def from_authorized_user_file_mock() -> abc.Generator[mock.Mock, None, None]:
     """
     For tlab_google.credentials.load_credentials
     """
@@ -35,7 +35,7 @@ def from_authorized_user_file_mock() -> t.Generator[mock.Mock, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def build_service_mock() -> t.Generator[mock.Mock, None, None]:
+def build_service_mock() -> abc.Generator[mock.Mock, None, None]:
     """
     For all google api
     """

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,5 +1,5 @@
 import os
-import typing as t
+from collections import abc
 from unittest import mock
 
 import pytest
@@ -22,7 +22,7 @@ def scopes(request: FixtureRequest[str]) -> list[str]:
 
 
 @pytest.fixture()
-def from_client_config_mock() -> t.Generator[mock.Mock, None, None]:
+def from_client_config_mock() -> abc.Generator[mock.Mock, None, None]:
     with mock.patch(
         "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config"
     ) as m:
@@ -91,7 +91,7 @@ def test_new_credentials_run_local_server(
 
 
 @pytest.fixture()
-def from_authorized_user_file_mock() -> t.Generator[mock.Mock, None, None]:
+def from_authorized_user_file_mock() -> abc.Generator[mock.Mock, None, None]:
     with mock.patch(
         "google.oauth2.credentials.Credentials.from_authorized_user_file"
     ) as m:

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,5 +1,6 @@
 import base64
 import typing as t
+from collections import abc
 from email.mime import text
 from unittest import mock
 
@@ -10,7 +11,7 @@ from tlab_google import credentials, gmail
 
 
 @pytest.fixture(autouse=True)
-def build_service_mock() -> t.Generator[mock.Mock, None, None]:
+def build_service_mock() -> abc.Generator[mock.Mock, None, None]:
     with mock.patch("tlab_google.utils.build_service") as m:
         yield m
 


### PR DESCRIPTION
- Fix `typing.Generator` to `collections.abc.Generator`